### PR TITLE
fix ruamel and pandas api

### DIFF
--- a/ctwrap/handler.py
+++ b/ctwrap/handler.py
@@ -464,6 +464,7 @@ def _worker(
     else:
         out = None
 
+    data = None
     other = None
     reschedule = 0
     while reschedule < len(tasks):
@@ -522,7 +523,7 @@ def _worker(
             errored = True
 
         # save output
-        if out and obj.data:
+        if out is not None and data is not None:
             if parallel:
                 with lock:
                     out.save(data, entry=task, variation=variations[task], errored=errored)

--- a/ctwrap/handler.py
+++ b/ctwrap/handler.py
@@ -60,11 +60,7 @@ import multiprocessing as mp
 from multiprocessing import queues as mpq
 from multiprocessing import synchronize as mps
 import queue  # imported for using queue.Empty exception
-
-try:
-    import ruamel_yaml as yaml
-except ImportError:
-    from ruamel import yaml
+from ruamel.yaml import YAML
 
 # ctwrap specific import
 from .parser import _parse, _write, Parser
@@ -169,7 +165,8 @@ class SimulationHandler(object):
                           "".format(yaml_file))
 
         with open(full_name) as stream:
-            content = yaml.load(stream, Loader=yaml.SafeLoader)
+            yaml = YAML(typ="safe")
+            content = yaml.load(stream)
 
         output = content.get('output', {})
 

--- a/ctwrap/output.py
+++ b/ctwrap/output.py
@@ -236,7 +236,7 @@ class WriteCSV(Output):
                 df = pd.read_csv(fname)
             else:
                 df = pd.DataFrame(columns=row.keys())
-            df = df.append(row, ignore_index=True)
+            df = pd.concat([df, row], ignore_index=True)
             df.to_csv(fname, index=False)
 
     def dir(self):

--- a/ctwrap/output.py
+++ b/ctwrap/output.py
@@ -14,15 +14,14 @@ import warnings
 
 from typing import Dict, List, Any, Optional, Union
 
-import pkg_resources
+import importlib
 
 # avoid explicit dependence on cantera
-try:
-    pkg_resources.get_distribution('cantera')
-except pkg_resources.DistributionNotFound:
+ct_spec = importlib.util.find_spec("cantera")
+if ct_spec is None:
     ct = ImportError('Method requires a working cantera installation.')
 else:
-    import cantera as ct
+    ct = importlib.import_module("cantera")
 
 
 class Output:

--- a/ctwrap/output.py
+++ b/ctwrap/output.py
@@ -235,7 +235,7 @@ class WriteCSV(Output):
                 df = pd.read_csv(fname)
             else:
                 df = pd.DataFrame(columns=row.keys())
-            df = pd.concat([df, row], ignore_index=True)
+            df = pd.concat([df, row.to_frame().T], ignore_index=True)
             df.to_csv(fname, index=False)
 
     def dir(self):
@@ -245,6 +245,7 @@ class WriteCSV(Output):
             return []
 
         df = pd.read_csv(fname)
+        print("DEBUG dir df", df)
         return list(df.output)
 
     def load_like(self, entry, other):

--- a/ctwrap/output.py
+++ b/ctwrap/output.py
@@ -194,7 +194,7 @@ class WriteCSV(Output):
 
     def save(self, data, entry, variation=None, mode=None, errored=False):
         ""
-        if not data:
+        if data is None:
             return
 
         returns = self.kwargs.get('returns')
@@ -237,6 +237,9 @@ class WriteCSV(Output):
                 df = pd.DataFrame(columns=row.keys())
             df = pd.concat([df, row.to_frame().T], ignore_index=True)
             df.to_csv(fname, index=False)
+
+        else:
+            raise NotImplementedError("Saving of '{}' not implemented".format(type(data).__name__))
 
     def dir(self):
         ""

--- a/ctwrap/output.py
+++ b/ctwrap/output.py
@@ -245,7 +245,6 @@ class WriteCSV(Output):
             return []
 
         df = pd.read_csv(fname)
-        print("DEBUG dir df", df)
         return list(df.output)
 
     def load_like(self, entry, other):

--- a/ctwrap/parser.py
+++ b/ctwrap/parser.py
@@ -264,6 +264,7 @@ class Parser(object):
 
     def to_yaml(self):
         """Convert Parser content to YAML string"""
+        yaml = YAML(typ="safe")
         return yaml.dump(self.raw, Dumper=yaml.SafeDumper)
 
     def get(self, key, default=None):

--- a/ctwrap/parser.py
+++ b/ctwrap/parser.py
@@ -249,7 +249,7 @@ class Parser(object):
         elif path is not None:
             fname = Path(path) / fname
 
-        yaml = YAML(typ="rt")
+        yaml = YAML(typ="safe")
         try:
             _ = fname.is_file()  # will raise error
             with open(fname) as stream:

--- a/ctwrap/parser.py
+++ b/ctwrap/parser.py
@@ -85,6 +85,7 @@ def _parse(val: str):
     Returns:
        `Tuple` containing value and unit
     """
+    # TODO :seems parser does not handle "e" scientific notation e.g; "1e-6 m**3" is not parsed as dimensioned unit. 
 
     if not isinstance(val, str):
         raise TypeError("Method requires string input")
@@ -254,6 +255,8 @@ class Parser(object):
             _ = fname.is_file()  # will raise error
             with open(fname) as stream:
                 out = yaml.load(stream)
+        except FileNotFoundError:
+            raise FileNotFoundError("File '{}' not found".format(fname))
         except OSError:
             out = yaml.load(yml)
 

--- a/ctwrap/parser.py
+++ b/ctwrap/parser.py
@@ -65,13 +65,9 @@ from pathlib import Path
 from typing import Optional, Dict, Any, Tuple, KeysView, Generator, Union
 from copy import deepcopy
 from pint import UnitRegistry
+from ruamel.yaml import YAML
 import warnings
 import re
-
-try:
-    import ruamel_yaml as yaml
-except ImportError:
-    from ruamel import yaml
 
 
 __all__ = ['Parser']
@@ -253,12 +249,13 @@ class Parser(object):
         elif path is not None:
             fname = Path(path) / fname
 
+        yaml = YAML(typ="rt")
         try:
-            _ = fname.is_file() # will raise error
+            _ = fname.is_file()  # will raise error
             with open(fname) as stream:
-                out = yaml.load(stream, Loader=yaml.SafeLoader)
+                out = yaml.load(stream)
         except OSError:
-            out = yaml.load(yml, Loader=yaml.SafeLoader)
+            out = yaml.load(yml)
 
         if keys is None:
             return cls(out)

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - h5py
   - pint
   - ruamel.yaml>=0.17.0
-  - pandas
+  - pandas>=1.4
   - cantera
   - setuptools
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - numpy
   - h5py
   - pint
-  - ruamel.yaml
+  - ruamel.yaml>=0.17.0
   - pandas
   - cantera
   - setuptools

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -7,11 +7,7 @@ import pytest
 import unittest
 from pathlib import Path
 import h5py
-
-try:
-    import ruamel_yaml as yaml
-except ImportError:
-    from ruamel import yaml
+from ruamel.yaml import YAML
 
 import warnings
 # add exception as pywintypes imports a deprecated module
@@ -46,7 +42,7 @@ class TestOutput(unittest.TestCase):
     def setUpClass(cls):
         with open(EXAMPLES / cls._yaml) as stream:
             yaml = YAML(typ='safe')
-            cls._config = yaml.load(stream, Loader=yaml.SafeLoader)
+            cls._config = yaml.load(stream)
 
         out = cls._config.get('output')
         if out:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -21,15 +21,14 @@ warnings.filterwarnings("ignore", ".*the imp module is deprecated*")
 # pylint: disable=no-member
 import ctwrap.output as cwo
 
-import pkg_resources
+import importlib
 
 # avoid explicit dependence on cantera
-try:
-    pkg_resources.get_distribution('cantera')
-except pkg_resources.DistributionNotFound:
+ct_spec = importlib.util.find_spec("cantera")
+if ct_spec is None:
     ct = ImportError('Method requires a working cantera installation.')
 else:
-    import cantera as ct
+    ct = importlib.import_module("cantera")
 
 
 PWD = Path(__file__).parents[0]
@@ -46,6 +45,7 @@ class TestOutput(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         with open(EXAMPLES / cls._yaml) as stream:
+            yaml = YAML(typ='safe')
             cls._config = yaml.load(stream, Loader=yaml.SafeLoader)
 
         out = cls._config.get('output')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,12 +5,8 @@
 
 import unittest
 from pathlib import Path
-import pint.quantity as pq
-
-try:
-    import ruamel_yaml as yaml
-except ImportError:
-    from ruamel import yaml
+import pint as pq
+from ruamel.yaml import YAML
 
 import warnings
 # add exception as pywintypes imports a deprecated module
@@ -202,6 +198,7 @@ class TestYAML(unittest.TestCase):
     def test_minimal(self):
 
         with open(EXAMPLES / 'minimal.yaml') as stream:
+            yaml = YAML(typ='safe')
             defaults = yaml.load(stream, Loader=yaml.SafeLoader)
         p = cw.Parser.from_yaml('minimal.yaml', path=EXAMPLES)
         self.assertEqual(len(p), len(defaults))
@@ -216,6 +213,7 @@ class TestYAML(unittest.TestCase):
     def test_ignition(self):
 
         with open(EXAMPLES / 'ignition.yaml') as stream:
+            yaml = YAML(typ='safe')
             yml = yaml.load(stream, Loader=yaml.SafeLoader)
         initial = cw.Parser(yml['defaults']['initial'])
         self.assertIsInstance(initial.T, pq.Quantity)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -199,7 +199,7 @@ class TestYAML(unittest.TestCase):
 
         with open(EXAMPLES / 'minimal.yaml') as stream:
             yaml = YAML(typ='safe')
-            defaults = yaml.load(stream, Loader=yaml.SafeLoader)
+            defaults = yaml.load(stream)
         p = cw.Parser.from_yaml('minimal.yaml', path=EXAMPLES)
         self.assertEqual(len(p), len(defaults))
         self.assertEqual(p.keys(), defaults.keys())
@@ -214,7 +214,7 @@ class TestYAML(unittest.TestCase):
 
         with open(EXAMPLES / 'ignition.yaml') as stream:
             yaml = YAML(typ='safe')
-            yml = yaml.load(stream, Loader=yaml.SafeLoader)
+            yml = yaml.load(stream)
         initial = cw.Parser(yml['defaults']['initial'])
         self.assertIsInstance(initial.T, pq.Quantity)
         self.assertIsInstance(initial['fuel'], str)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -5,12 +5,6 @@
 
 import unittest
 from pathlib import Path
-import pint.quantity as pq
-
-try:
-    import ruamel_yaml as yaml
-except ImportError:
-    from ruamel import yaml
 
 import warnings
 # add exception as pywintypes imports a deprecated module

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -6,14 +6,9 @@
 import unittest
 from pathlib import Path
 import subprocess
-import pint.quantity as pq
 import importlib
 import h5py
-
-try:
-    import ruamel_yaml as yaml
-except ImportError:
-    from ruamel import yaml
+from ruamel.yaml import YAML
 
 import warnings
 # add exception as pywintypes imports a deprecated module
@@ -54,7 +49,8 @@ class TestWrap(unittest.TestCase):
 
     def setUp(self):
         with open(EXAMPLES / self._yaml) as stream:
-            self.config = yaml.load(stream, Loader=yaml.SafeLoader)
+            yaml = YAML(typ='safe')
+            self.config = yaml.load(stream)
         self.sim = cw.Simulation.from_module(self._module)
         self.sh = cw.SimulationHandler.from_yaml(self._yaml, strategy=self._strategy, database=EXAMPLES)
 
@@ -247,7 +243,8 @@ class TestInvalid(TestWrap):
 
     def setUp(self):
         with open(EXAMPLES / self._yaml) as stream:
-            self.config = yaml.load(stream, Loader=yaml.SafeLoader)
+            yaml = YAML(typ='safe')
+            self.config = yaml.load(stream)
         self.sim = cw.Simulation.from_module(self._module)
         self.sh = cw.SimulationHandler.from_dict(self._dict)
 


### PR DESCRIPTION
## API updates

- [x] Fixing deprecation of yaml.load after 0.17.0

https://yaml.readthedocs.io/api/#transparent-usage-of-new-and-old-api

Fixes #92 

- [x] Also fixing deprecation of [pandas.DataFrame.append](https://github.com/pandas-dev/pandas/issues/35407) beyond pandas>=1.4

```python
# df = df.append(row, ignore_index=True)          # old syntax
 df = pd.concat([df, row.to_frame().T], ignore_index=True)
```

Also : 
- [x] fixed `pkg_resources` 
- [x] fixed `pint` 

## Result

List of Tests :

```bash
pytest .
```

```bash
================================================= test session starts =================================================
platform win32 -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0 -- C:\Users\erwan\anaconda3\envs\bloc\python.exe
cachedir: .pytest_cache
rootdir: C:\GitHub\ctwrap
configfile: pytest.ini
plugins: dash-2.18.2, cov-6.0.0
collected 147 items

tests/test_notebooks.py::TestNotebooks::test_commandline_example FAILED                                          [  0%]
tests/test_notebooks.py::TestNotebooks::test_equilibrium_example FAILED                                          [  1%]
tests/test_notebooks.py::TestNotebooks::test_freeflame_example FAILED                                            [  2%]
tests/test_notebooks.py::TestNotebooks::test_ignition_example FAILED                                             [  2%]
tests/test_notebooks.py::TestNotebooks::test_minimal_example FAILED                                              [  3%]
tests/test_output.py::TestOutput::test_dir PASSED                                                                [  4%]
tests/test_output.py::TestOutput::test_output PASSED                                                             [  4%]
tests/test_output.py::TestCSV::test_csv PASSED                                                                   [  5%]
tests/test_output.py::TestCSV::test_dir PASSED                                                                   [  6%]
tests/test_output.py::TestCSV::test_output PASSED                                                                [  6%]
tests/test_output.py::TestSolution::test_add PASSED                                                              [  7%]
tests/test_output.py::TestSolution::test_csv PASSED                                                              [  8%]
tests/test_output.py::TestSolution::test_dir PASSED                                                              [  8%]
tests/test_output.py::TestSolution::test_output PASSED                                                           [  9%]
tests/test_output.py::TestMixture::test_add PASSED                                                               [ 10%]
tests/test_output.py::TestMixture::test_csv PASSED                                                               [ 10%]
tests/test_output.py::TestMixture::test_dir PASSED                                                               [ 11%]
tests/test_output.py::TestMixture::test_output PASSED                                                            [ 12%]
tests/test_output.py::TestHDF::test_dir PASSED                                                                   [ 12%]
tests/test_output.py::TestHDF::test_hdf PASSED                                                                   [ 13%]
tests/test_output.py::TestHDF::test_output PASSED                                                                [ 14%]
tests/test_output.py::TestSolutionArray::test_dir FAILED                                                         [ 14%]
tests/test_output.py::TestSolutionArray::test_hdf FAILED                                                         [ 15%]
tests/test_output.py::TestSolutionArray::test_load_like FAILED                                                   [ 16%]
tests/test_output.py::TestSolutionArray::test_output FAILED                                                      [ 17%]
tests/test_output.py::TestFreeFlame::test_dir FAILED                                                             [ 17%]
tests/test_output.py::TestFreeFlame::test_load_like FAILED                                                       [ 18%]
tests/test_output.py::TestFreeFlame::test_output FAILED                                                          [ 19%]
tests/test_parser.py::TestUpdate::test_level1 PASSED                                                             [ 19%]
tests/test_parser.py::TestUpdate::test_level2 PASSED                                                             [ 20%]
tests/test_parser.py::TestUpdate::test_multi_level PASSED                                                        [ 21%]
tests/test_parser.py::TestParse::test_full PASSED                                                                [ 21%]
tests/test_parser.py::TestParse::test_no_unit1 PASSED                                                            [ 22%]
tests/test_parser.py::TestParse::test_no_unit2 PASSED                                                            [ 23%]
tests/test_parser.py::TestParse::test_string PASSED                                                              [ 23%]
tests/test_parser.py::TestWrite::test_full PASSED                                                                [ 24%]
tests/test_parser.py::TestWrite::test_no_unit1 PASSED                                                            [ 25%]
tests/test_parser.py::TestWrite::test_no_unit2 PASSED                                                            [ 25%]
tests/test_parser.py::TestWrite::test_string PASSED                                                              [ 26%]
tests/test_parser.py::TestPassing::test_parser PASSED                                                            [ 27%]
tests/test_parser.py::TestKeyStr::test_parser PASSED                                                             [ 27%]
tests/test_parser.py::TestNone::test_parser PASSED                                                               [ 28%]
tests/test_parser.py::TestParser::test_parser PASSED                                                             [ 29%]
tests/test_parser.py::TestMulti::test_parser PASSED                                                              [ 29%]
tests/test_parser.py::TestMulti::test_update_dict PASSED                                                         [ 30%]
tests/test_parser.py::TestMulti::test_update_parser PASSED                                                       [ 31%]
tests/test_parser.py::TestFailing::test_parser PASSED                                                            [ 31%]
tests/test_parser.py::TestInt::test_parser PASSED                                                                [ 32%]
tests/test_parser.py::TestFloat::test_parser PASSED                                                              [ 33%]
tests/test_parser.py::TestString::test_parser PASSED                                                             [ 34%]
tests/test_parser.py::TestYAML::test_freeflame PASSED                                                            [ 34%]
tests/test_parser.py::TestYAML::test_ignition FAILED                                                             [ 35%]
tests/test_parser.py::TestYAML::test_minimal FAILED                                                              [ 36%]
tests/test_strategy.py::TestReplace::test_entry PASSED                                                           [ 36%]
tests/test_strategy.py::TestReplace::test_missing1 PASSED                                                        [ 37%]
tests/test_strategy.py::TestReplace::test_missing2 PASSED                                                        [ 38%]
tests/test_strategy.py::TestReplace::test_nested PASSED                                                          [ 38%]
tests/test_strategy.py::TestParse::test_arange PASSED                                                            [ 39%]
tests/test_strategy.py::TestParse::test_linspace PASSED                                                          [ 40%]
tests/test_strategy.py::TestSweep::test_one PASSED                                                               [ 40%]
tests/test_strategy.py::TestSweep::test_three PASSED                                                             [ 41%]
tests/test_strategy.py::TestSweep::test_two PASSED                                                               [ 42%]
tests/test_strategy.py::TestStrategy::test_legacy PASSED                                                         [ 42%]
tests/test_strategy.py::TestStrategy::test_load PASSED                                                           [ 43%]
tests/test_strategy.py::TestStrategy::test_matrix PASSED                                                         [ 44%]
tests/test_strategy.py::TestStrategy::test_minimal PASSED                                                        [ 44%]
tests/test_strategy.py::TestStrategy::test_raises PASSED                                                         [ 45%]
tests/test_strategy.py::TestStrategy::test_sequence PASSED                                                       [ 46%]
tests/test_wrapper.py::TestLegacy::test_database PASSED                                                          [ 46%]
tests/test_wrapper.py::TestLegacy::test_handler PASSED                                                           [ 47%]
tests/test_wrapper.py::TestWrap::test_commandline PASSED                                                         [ 48%]
tests/test_wrapper.py::TestWrap::test_handler PASSED                                                             [ 48%]
tests/test_wrapper.py::TestWrap::test_main PASSED                                                                [ 49%]
tests/test_wrapper.py::TestWrap::test_parallel PASSED                                                            [ 50%]
tests/test_wrapper.py::TestWrap::test_restart PASSED                                                             [ 51%]
tests/test_wrapper.py::TestWrap::test_serial PASSED                                                              [ 51%]
tests/test_wrapper.py::TestWrap::test_simulation PASSED                                                          [ 52%]
tests/test_wrapper.py::TestMatrix::test_commandline PASSED                                                       [ 53%]
tests/test_wrapper.py::TestMatrix::test_handler PASSED                                                           [ 53%]
tests/test_wrapper.py::TestMatrix::test_main PASSED                                                              [ 54%]
tests/test_wrapper.py::TestMatrix::test_parallel PASSED                                                          [ 55%]
tests/test_wrapper.py::TestMatrix::test_restart PASSED                                                           [ 55%]
tests/test_wrapper.py::TestMatrix::test_serial PASSED                                                            [ 56%]
tests/test_wrapper.py::TestMatrix::test_simulation PASSED                                                        [ 57%]
tests/test_wrapper.py::TestLocal::test_commandline PASSED                                                        [ 57%]
tests/test_wrapper.py::TestLocal::test_handler PASSED                                                            [ 58%]
tests/test_wrapper.py::TestLocal::test_main PASSED                                                               [ 59%]
tests/test_wrapper.py::TestLocal::test_parallel PASSED                                                           [ 59%]
tests/test_wrapper.py::TestLocal::test_restart PASSED                                                            [ 60%]
tests/test_wrapper.py::TestLocal::test_serial PASSED                                                             [ 61%]
tests/test_wrapper.py::TestLocal::test_simulation PASSED                                                         [ 61%]
tests/test_wrapper.py::TestCustom::test_commandline PASSED                                                       [ 62%]
tests/test_wrapper.py::TestCustom::test_handler PASSED                                                           [ 63%]
tests/test_wrapper.py::TestCustom::test_main PASSED                                                              [ 63%]
tests/test_wrapper.py::TestCustom::test_parallel PASSED                                                          [ 64%]
tests/test_wrapper.py::TestCustom::test_restart PASSED                                                           [ 65%]
tests/test_wrapper.py::TestCustom::test_serial PASSED                                                            [ 65%]
tests/test_wrapper.py::TestCustom::test_simulation PASSED                                                        [ 66%]
tests/test_wrapper.py::TestIgnition::test_commandline PASSED                                                     [ 67%]
tests/test_wrapper.py::TestIgnition::test_handler PASSED                                                         [ 68%]
tests/test_wrapper.py::TestIgnition::test_main PASSED                                                            [ 68%]
tests/test_wrapper.py::TestIgnition::test_parallel FAILED                                                        [ 69%]
tests/test_wrapper.py::TestIgnition::test_restart PASSED                                                         [ 70%]
tests/test_wrapper.py::TestIgnition::test_serial PASSED                                                          [ 70%]
tests/test_wrapper.py::TestIgnition::test_simulation PASSED                                                      [ 71%]
tests/test_wrapper.py::TestSolution::test_commandline PASSED                                                                                [ 72%]
tests/test_wrapper.py::TestSolution::test_handler PASSED                                                                                    [ 72%]
tests/test_wrapper.py::TestSolution::test_main PASSED                                                                                       [ 73%]
tests/test_wrapper.py::TestSolution::test_parallel PASSED                                                                                   [ 74%]
tests/test_wrapper.py::TestSolution::test_restart PASSED                                                                                    [ 74%]
tests/test_wrapper.py::TestSolution::test_serial PASSED                                                                                     [ 75%]
tests/test_wrapper.py::TestSolution::test_simulation PASSED                                                                                 [ 76%]
tests/test_wrapper.py::TestEquilibrium::test_commandline PASSED                                                                             [ 76%]
tests/test_wrapper.py::TestEquilibrium::test_handler PASSED                                                                                 [ 77%]
tests/test_wrapper.py::TestEquilibrium::test_main PASSED                                                                                    [ 78%]
tests/test_wrapper.py::TestEquilibrium::test_parallel PASSED                                                                                [ 78%]
tests/test_wrapper.py::TestEquilibrium::test_restart PASSED                                                                                 [ 79%]
tests/test_wrapper.py::TestEquilibrium::test_serial PASSED                                                                                  [ 80%]
tests/test_wrapper.py::TestEquilibrium::test_simulation PASSED                                                                              [ 80%]
tests/test_wrapper.py::TestEquilibriumMulti::test_commandline PASSED                                                                        [ 81%]
tests/test_wrapper.py::TestEquilibriumMulti::test_handler PASSED                                                                            [ 82%]
tests/test_wrapper.py::TestEquilibriumMulti::test_main PASSED                                                                               [ 82%]
tests/test_wrapper.py::TestEquilibriumMulti::test_parallel PASSED                                                                           [ 83%]
tests/test_wrapper.py::TestEquilibriumMulti::test_restart PASSED                                                                            [ 84%]
tests/test_wrapper.py::TestEquilibriumMulti::test_serial PASSED                                                                             [ 85%]
tests/test_wrapper.py::TestEquilibriumMulti::test_simulation PASSED                                                                         [ 85%]
tests/test_wrapper.py::TestFreeFlame::test_commandline FAILED                                                                               [ 86%]
tests/test_wrapper.py::TestFreeFlame::test_handler PASSED                                                                                   [ 87%]
tests/test_wrapper.py::TestFreeFlame::test_main FAILED                                                                                      [ 87%]
tests/test_wrapper.py::TestFreeFlame::test_parallel FAILED                                                                                  [ 88%]
tests/test_wrapper.py::TestFreeFlame::test_restart PASSED                                                                                   [ 89%]
tests/test_wrapper.py::TestFreeFlame::test_serial FAILED                                                                                    [ 89%]
tests/test_wrapper.py::TestFreeFlame::test_simulation PASSED                                                                                [ 90%]
tests/test_wrapper.py::TestFreeFlameMatrix::test_commandline PASSED                                                                         [ 91%]
tests/test_wrapper.py::TestFreeFlameMatrix::test_handler PASSED                                                                             [ 91%]
tests/test_wrapper.py::TestFreeFlameMatrix::test_main FAILED                                                                                [ 92%]
tests/test_wrapper.py::TestFreeFlameMatrix::test_parallel FAILED                                                                            [ 93%]
tests/test_wrapper.py::TestFreeFlameMatrix::test_restart PASSED                                                                             [ 93%]
tests/test_wrapper.py::TestFreeFlameMatrix::test_serial PASSED                                                                              [ 94%]
tests/test_wrapper.py::TestFreeFlameMatrix::test_simulation PASSED                                                                          [ 95%]
tests/test_wrapper.py::TestInvalid::test_commandline PASSED                                                                                 [ 95%]
tests/test_wrapper.py::TestInvalid::test_handler PASSED                                                                                     [ 96%]
tests/test_wrapper.py::TestInvalid::test_main PASSED                                                                                        [ 97%]
tests/test_wrapper.py::TestInvalid::test_parallel PASSED                                                                                    [ 97%]
tests/test_wrapper.py::TestInvalid::test_restart PASSED                                                                                     [ 98%]
tests/test_wrapper.py::TestInvalid::test_serial PASSED                                                                                      [ 99%]
tests/test_wrapper.py::TestInvalid::test_simulation PASSED                                                                                  [100%]
```


Detail : 

<details>

```

==================================================================== FAILURES ====================================================================
_____________________________________________________ TestNotebooks.test_commandline_example _____________________________________________________

self = <test_notebooks.TestNotebooks testMethod=test_commandline_example>

    def test_func(self):
        print('\n--------------- Testing {0} ---------------'.format(nbname))
        print('   {0}'.format(nbpath))
        # execute the notebook using nbconvert to generate html
        nbexe = subprocess.Popen(['jupyter', 'nbconvert', '--to', 'html',
                                  '{0}'.format(nbpath),
                                  '--execute',
                                  '--ExecutePreprocessor.timeout=180'],
                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
        _, err = nbexe.communicate()
        failed = nbexe.returncode
        if failed:
            print('\n <<<<< {0} FAILED >>>>> \n'.format(nbname))
            print('Captured Output: \n\n{0}'.format(err.decode("utf-8")))
        else:
            print('\n ..... {0} Passed ..... \n'.format(nbname))
            # if passed remove the generated html file
            subprocess.call(['rm', str(nbpath.with_suffix('.html'))])

>       self.assertFalse(failed)
E       AssertionError: 1 is not false

tests\test_notebooks.py:46: AssertionError
-------------------------------------------------------------- Captured stdout call --------------------------------------------------------------

--------------- Testing commandline_example ---------------
   C:\GitHub\ctwrap\docs\examples\commandline_example.ipynb

 <<<<< commandline_example FAILED >>>>>

Captured Output:

usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
               [--paths] [--json] [--debug]
               [subcommand]

Jupyter: Interactive Computing

positional arguments:
  subcommand     the subcommand to launch

options:
  -h, --help     show this help message and exit
  --version      show the versions of core jupyter packages and exit
  --config-dir   show Jupyter config dir
  --data-dir     show Jupyter data dir
  --runtime-dir  show Jupyter runtime dir
  --paths        show all Jupyter paths. Add --json for machine-readable
                 format.
  --json         output paths as machine-readable json
  --debug        output debug information about paths

Available subcommands: kernel kernelspec migrate run script troubleshoot

Jupyter command `jupyter-nbconvert` not found.

_____________________________________________________ TestNotebooks.test_equilibrium_example _____________________________________________________

self = <test_notebooks.TestNotebooks testMethod=test_equilibrium_example>

    def test_func(self):
        print('\n--------------- Testing {0} ---------------'.format(nbname))
        print('   {0}'.format(nbpath))
        # execute the notebook using nbconvert to generate html
        nbexe = subprocess.Popen(['jupyter', 'nbconvert', '--to', 'html',
                                  '{0}'.format(nbpath),
                                  '--execute',
                                  '--ExecutePreprocessor.timeout=180'],
                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
        _, err = nbexe.communicate()
        failed = nbexe.returncode
        if failed:
            print('\n <<<<< {0} FAILED >>>>> \n'.format(nbname))
            print('Captured Output: \n\n{0}'.format(err.decode("utf-8")))
        else:
            print('\n ..... {0} Passed ..... \n'.format(nbname))
            # if passed remove the generated html file
            subprocess.call(['rm', str(nbpath.with_suffix('.html'))])

>       self.assertFalse(failed)
E       AssertionError: 1 is not false

tests\test_notebooks.py:46: AssertionError
-------------------------------------------------------------- Captured stdout call --------------------------------------------------------------

--------------- Testing equilibrium_example ---------------
   C:\GitHub\ctwrap\docs\examples\equilibrium_example.ipynb

 <<<<< equilibrium_example FAILED >>>>>

Captured Output:

usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
               [--paths] [--json] [--debug]
               [subcommand]

Jupyter: Interactive Computing

positional arguments:
  subcommand     the subcommand to launch

options:
  -h, --help     show this help message and exit
  --version      show the versions of core jupyter packages and exit
  --config-dir   show Jupyter config dir
  --data-dir     show Jupyter data dir
  --runtime-dir  show Jupyter runtime dir
  --paths        show all Jupyter paths. Add --json for machine-readable
                 format.
  --json         output paths as machine-readable json
  --debug        output debug information about paths

Available subcommands: kernel kernelspec migrate run script troubleshoot

Jupyter command `jupyter-nbconvert` not found.

______________________________________________________ TestNotebooks.test_freeflame_example ______________________________________________________

self = <test_notebooks.TestNotebooks testMethod=test_freeflame_example>

    def test_func(self):
        print('\n--------------- Testing {0} ---------------'.format(nbname))
        print('   {0}'.format(nbpath))
        # execute the notebook using nbconvert to generate html
        nbexe = subprocess.Popen(['jupyter', 'nbconvert', '--to', 'html',
                                  '{0}'.format(nbpath),
                                  '--execute',
                                  '--ExecutePreprocessor.timeout=180'],
                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
        _, err = nbexe.communicate()
        failed = nbexe.returncode
        if failed:
            print('\n <<<<< {0} FAILED >>>>> \n'.format(nbname))
            print('Captured Output: \n\n{0}'.format(err.decode("utf-8")))
        else:
            print('\n ..... {0} Passed ..... \n'.format(nbname))
            # if passed remove the generated html file
            subprocess.call(['rm', str(nbpath.with_suffix('.html'))])

>       self.assertFalse(failed)
E       AssertionError: 1 is not false

tests\test_notebooks.py:46: AssertionError
-------------------------------------------------------------- Captured stdout call --------------------------------------------------------------

--------------- Testing freeflame_example ---------------
   C:\GitHub\ctwrap\docs\examples\freeflame_example.ipynb

 <<<<< freeflame_example FAILED >>>>>

Captured Output:

usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
               [--paths] [--json] [--debug]
               [subcommand]

Jupyter: Interactive Computing

positional arguments:
  subcommand     the subcommand to launch

options:
  -h, --help     show this help message and exit
  --version      show the versions of core jupyter packages and exit
  --config-dir   show Jupyter config dir
  --data-dir     show Jupyter data dir
  --runtime-dir  show Jupyter runtime dir
  --paths        show all Jupyter paths. Add --json for machine-readable
                 format.
  --json         output paths as machine-readable json
  --debug        output debug information about paths

Available subcommands: kernel kernelspec migrate run script troubleshoot

Jupyter command `jupyter-nbconvert` not found.

______________________________________________________ TestNotebooks.test_ignition_example _______________________________________________________

self = <test_notebooks.TestNotebooks testMethod=test_ignition_example>

    def test_func(self):
        print('\n--------------- Testing {0} ---------------'.format(nbname))
        print('   {0}'.format(nbpath))
        # execute the notebook using nbconvert to generate html
        nbexe = subprocess.Popen(['jupyter', 'nbconvert', '--to', 'html',
                                  '{0}'.format(nbpath),
                                  '--execute',
                                  '--ExecutePreprocessor.timeout=180'],
                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
        _, err = nbexe.communicate()
        failed = nbexe.returncode
        if failed:
            print('\n <<<<< {0} FAILED >>>>> \n'.format(nbname))
            print('Captured Output: \n\n{0}'.format(err.decode("utf-8")))
        else:
            print('\n ..... {0} Passed ..... \n'.format(nbname))
            # if passed remove the generated html file
            subprocess.call(['rm', str(nbpath.with_suffix('.html'))])

>       self.assertFalse(failed)
E       AssertionError: 1 is not false

tests\test_notebooks.py:46: AssertionError
-------------------------------------------------------------- Captured stdout call --------------------------------------------------------------

--------------- Testing ignition_example ---------------
   C:\GitHub\ctwrap\docs\examples\ignition_example.ipynb

 <<<<< ignition_example FAILED >>>>>

Captured Output:

usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
               [--paths] [--json] [--debug]
               [subcommand]

Jupyter: Interactive Computing

positional arguments:
  subcommand     the subcommand to launch

options:
  -h, --help     show this help message and exit
  --version      show the versions of core jupyter packages and exit
  --config-dir   show Jupyter config dir
  --data-dir     show Jupyter data dir
  --runtime-dir  show Jupyter runtime dir
  --paths        show all Jupyter paths. Add --json for machine-readable
                 format.
  --json         output paths as machine-readable json
  --debug        output debug information about paths

Available subcommands: kernel kernelspec migrate run script troubleshoot

Jupyter command `jupyter-nbconvert` not found.

_______________________________________________________ TestNotebooks.test_minimal_example _______________________________________________________

self = <test_notebooks.TestNotebooks testMethod=test_minimal_example>

    def test_func(self):
        print('\n--------------- Testing {0} ---------------'.format(nbname))
        print('   {0}'.format(nbpath))
        # execute the notebook using nbconvert to generate html
        nbexe = subprocess.Popen(['jupyter', 'nbconvert', '--to', 'html',
                                  '{0}'.format(nbpath),
                                  '--execute',
                                  '--ExecutePreprocessor.timeout=180'],
                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
        _, err = nbexe.communicate()
        failed = nbexe.returncode
        if failed:
            print('\n <<<<< {0} FAILED >>>>> \n'.format(nbname))
            print('Captured Output: \n\n{0}'.format(err.decode("utf-8")))
        else:
            print('\n ..... {0} Passed ..... \n'.format(nbname))
            # if passed remove the generated html file
            subprocess.call(['rm', str(nbpath.with_suffix('.html'))])

>       self.assertFalse(failed)
E       AssertionError: 1 is not false

tests\test_notebooks.py:46: AssertionError
-------------------------------------------------------------- Captured stdout call --------------------------------------------------------------

--------------- Testing minimal_example ---------------
   C:\GitHub\ctwrap\docs\examples\minimal_example.ipynb

 <<<<< minimal_example FAILED >>>>>

Captured Output:

usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
               [--paths] [--json] [--debug]
               [subcommand]

Jupyter: Interactive Computing

positional arguments:
  subcommand     the subcommand to launch

options:
  -h, --help     show this help message and exit
  --version      show the versions of core jupyter packages and exit
  --config-dir   show Jupyter config dir
  --data-dir     show Jupyter data dir
  --runtime-dir  show Jupyter runtime dir
  --paths        show all Jupyter paths. Add --json for machine-readable
                 format.
  --json         output paths as machine-readable json
  --debug        output debug information about paths

Available subcommands: kernel kernelspec migrate run script troubleshoot

Jupyter command `jupyter-nbconvert` not found.

___________________________________________________________ TestSolutionArray.test_dir ___________________________________________________________

self = <test_output.TestSolutionArray testMethod=test_dir>

    def setUp(self):
        self._gas = ct.Solution('h2o2.yaml')
        self._arr = ct.SolutionArray(self._gas, 2)
        self._arr.TP = 300., ct.one_atm
>       self._output.save(self._arr, 'foo')

tests\test_output.py:143:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ctwrap\output.py:274: in save
    _save_hdf(data, self.settings, entry, variation, errored)
ctwrap\output.py:395: in _save_hdf
    data.write_hdf(filename=filename, group=entry,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self =       T          D   H2    H    O   O2   OH  H2O  HO2 H2O2   AR   N2
0   300  0.0818939    1    0    0    0    0    0 ...0    0    0
1   300  0.0818939    1    0    0    0    0    0    0    0    0    0

[2 rows x 12 components; state='TDY']
name = 'write_hdf'

    def __getattr__(self, name):
        if self._has_component(name):
            out = self._get_component(name)
            out.setflags(write=False)
            return out.reshape(self.shape + out.shape[1:])
        elif name in self.__dict__:
            super().__getattr__(name)
        else:
>           raise AttributeError(
                f"{self.__class__.__name__!r} object has no attribute '{name}'")
E           AttributeError: 'SolutionArray' object has no attribute 'write_hdf'

C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py:684: AttributeError
___________________________________________________________ TestSolutionArray.test_hdf ___________________________________________________________

self = <test_output.TestSolutionArray testMethod=test_hdf>

    def setUp(self):
        self._gas = ct.Solution('h2o2.yaml')
        self._arr = ct.SolutionArray(self._gas, 2)
        self._arr.TP = 300., ct.one_atm
>       self._output.save(self._arr, 'foo')

tests\test_output.py:143:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ctwrap\output.py:274: in save
    _save_hdf(data, self.settings, entry, variation, errored)
ctwrap\output.py:395: in _save_hdf
    data.write_hdf(filename=filename, group=entry,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self =       T          D   H2    H    O   O2   OH  H2O  HO2 H2O2   AR   N2
0   300  0.0818939    1    0    0    0    0    0 ...0    0    0
1   300  0.0818939    1    0    0    0    0    0    0    0    0    0

[2 rows x 12 components; state='TDY']
name = 'write_hdf'

    def __getattr__(self, name):
        if self._has_component(name):
            out = self._get_component(name)
            out.setflags(write=False)
            return out.reshape(self.shape + out.shape[1:])
        elif name in self.__dict__:
            super().__getattr__(name)
        else:
>           raise AttributeError(
                f"{self.__class__.__name__!r} object has no attribute '{name}'")
E           AttributeError: 'SolutionArray' object has no attribute 'write_hdf'

C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py:684: AttributeError
________________________________________________________ TestSolutionArray.test_load_like ________________________________________________________

self = <test_output.TestSolutionArray testMethod=test_load_like>

    def setUp(self):
        self._gas = ct.Solution('h2o2.yaml')
        self._arr = ct.SolutionArray(self._gas, 2)
        self._arr.TP = 300., ct.one_atm
>       self._output.save(self._arr, 'foo')

tests\test_output.py:143:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ctwrap\output.py:274: in save
    _save_hdf(data, self.settings, entry, variation, errored)
ctwrap\output.py:395: in _save_hdf
    data.write_hdf(filename=filename, group=entry,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self =       T          D   H2    H    O   O2   OH  H2O  HO2 H2O2   AR   N2
0   300  0.0818939    1    0    0    0    0    0 ...0    0    0
1   300  0.0818939    1    0    0    0    0    0    0    0    0    0

[2 rows x 12 components; state='TDY']
name = 'write_hdf'

    def __getattr__(self, name):
        if self._has_component(name):
            out = self._get_component(name)
            out.setflags(write=False)
            return out.reshape(self.shape + out.shape[1:])
        elif name in self.__dict__:
            super().__getattr__(name)
        else:
>           raise AttributeError(
                f"{self.__class__.__name__!r} object has no attribute '{name}'")
E           AttributeError: 'SolutionArray' object has no attribute 'write_hdf'

C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py:684: AttributeError
_________________________________________________________ TestSolutionArray.test_output __________________________________________________________

self = <test_output.TestSolutionArray testMethod=test_output>

    def setUp(self):
        self._gas = ct.Solution('h2o2.yaml')
        self._arr = ct.SolutionArray(self._gas, 2)
        self._arr.TP = 300., ct.one_atm
>       self._output.save(self._arr, 'foo')

tests\test_output.py:143:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ctwrap\output.py:274: in save
    _save_hdf(data, self.settings, entry, variation, errored)
ctwrap\output.py:395: in _save_hdf
    data.write_hdf(filename=filename, group=entry,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self =       T          D   H2    H    O   O2   OH  H2O  HO2 H2O2   AR   N2
0   300  0.0818939    1    0    0    0    0    0 ...0    0    0
1   300  0.0818939    1    0    0    0    0    0    0    0    0    0

[2 rows x 12 components; state='TDY']
name = 'write_hdf'

    def __getattr__(self, name):
        if self._has_component(name):
            out = self._get_component(name)
            out.setflags(write=False)
            return out.reshape(self.shape + out.shape[1:])
        elif name in self.__dict__:
            super().__getattr__(name)
        else:
>           raise AttributeError(
                f"{self.__class__.__name__!r} object has no attribute '{name}'")
E           AttributeError: 'SolutionArray' object has no attribute 'write_hdf'

C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py:684: AttributeError
_____________________________________________________________ TestFreeFlame.test_dir _____________________________________________________________

self = <test_output.TestFreeFlame testMethod=test_dir>

    def setUp(self):
        self._gas = ct.Solution('h2o2.yaml')
        self._gas.TP = 300., ct.one_atm
        f = ct.FreeFlame(self._gas)
>       self._output.save(f, 'foo')

tests\test_output.py:162:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ctwrap\output.py:274: in save
    _save_hdf(data, self.settings, entry, variation, errored)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

data = <cantera.onedim.FreeFlame object at 0x000002B31F71EAC0>, settings = {'mode': 'a'}, entry = 'foo', variation = None, errored = False

    def _save_hdf(data, settings, entry, variation, errored=False):
        filename = settings.pop('name')
        mode = settings.pop('mode', 'a')

        if filename is None:
            return

        filepath = settings.pop('path')
        force = settings.pop('force')
        settings.pop('format')

        if filepath is not None:
            filename = Path(filepath) / filename

        # file check
        fexists = Path(filename).is_file()

        if fexists:
            with h5py.File(filename, 'r') as hdf:
                for group in hdf.keys():
                    if group == entry and mode == 'a' and not force:
                        msg = ('Cannot overwrite existing '
                               'group `{}` (use force to override)')
                        raise RuntimeError(msg.format(entry))
                    elif group == entry and mode == 'a' and force:
                        mode = 'w'

        settings.update(mode=mode)

        hdf_kwargs = {'mode', 'append', 'compression', 'compression_opts'}
        kwargs = {k: v for k, v in settings.items() if k in hdf_kwargs}

        if errored:
            with h5py.File(filename, mode) as hdf:
                grp = hdf.create_group(entry)
                grp.attrs[data[0]] = data[1]
        else:
            if type(data).__name__ == 'SolutionArray':
                if variation is not None:
                    attrs = variation
                else:
                    attrs = {}
                data.write_hdf(filename=filename, group=entry,
                               attrs=attrs, **kwargs)
            elif type(data).__name__ in ['FreeFlame']:
                if variation is not None:
                    description = '_'.join(['{}_{}'.format(k, v) for k, v in variation.items()])
                else:
                    description = None
>               data.write_hdf(filename=filename, group=entry,
                               description=description, **kwargs)
E               AttributeError: 'FreeFlame' object has no attribute 'write_hdf'

ctwrap\output.py:402: AttributeError
__________________________________________________________ TestFreeFlame.test_load_like __________________________________________________________

self = <test_output.TestFreeFlame testMethod=test_load_like>

    def setUp(self):
        self._gas = ct.Solution('h2o2.yaml')
        self._gas.TP = 300., ct.one_atm
        f = ct.FreeFlame(self._gas)
>       self._output.save(f, 'foo')

tests\test_output.py:162:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ctwrap\output.py:274: in save
    _save_hdf(data, self.settings, entry, variation, errored)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

data = <cantera.onedim.FreeFlame object at 0x000002B31F5D4040>, settings = {'mode': 'a'}, entry = 'foo', variation = None, errored = False

    def _save_hdf(data, settings, entry, variation, errored=False):
        filename = settings.pop('name')
        mode = settings.pop('mode', 'a')

        if filename is None:
            return

        filepath = settings.pop('path')
        force = settings.pop('force')
        settings.pop('format')

        if filepath is not None:
            filename = Path(filepath) / filename

        # file check
        fexists = Path(filename).is_file()

        if fexists:
            with h5py.File(filename, 'r') as hdf:
                for group in hdf.keys():
                    if group == entry and mode == 'a' and not force:
                        msg = ('Cannot overwrite existing '
                               'group `{}` (use force to override)')
                        raise RuntimeError(msg.format(entry))
                    elif group == entry and mode == 'a' and force:
                        mode = 'w'

        settings.update(mode=mode)

        hdf_kwargs = {'mode', 'append', 'compression', 'compression_opts'}
        kwargs = {k: v for k, v in settings.items() if k in hdf_kwargs}

        if errored:
            with h5py.File(filename, mode) as hdf:
                grp = hdf.create_group(entry)
                grp.attrs[data[0]] = data[1]
        else:
            if type(data).__name__ == 'SolutionArray':
                if variation is not None:
                    attrs = variation
                else:
                    attrs = {}
                data.write_hdf(filename=filename, group=entry,
                               attrs=attrs, **kwargs)
            elif type(data).__name__ in ['FreeFlame']:
                if variation is not None:
                    description = '_'.join(['{}_{}'.format(k, v) for k, v in variation.items()])
                else:
                    description = None
>               data.write_hdf(filename=filename, group=entry,
                               description=description, **kwargs)
E               AttributeError: 'FreeFlame' object has no attribute 'write_hdf'

ctwrap\output.py:402: AttributeError
___________________________________________________________ TestFreeFlame.test_output ____________________________________________________________

self = <test_output.TestFreeFlame testMethod=test_output>

    def setUp(self):
        self._gas = ct.Solution('h2o2.yaml')
        self._gas.TP = 300., ct.one_atm
        f = ct.FreeFlame(self._gas)
>       self._output.save(f, 'foo')

tests\test_output.py:162:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ctwrap\output.py:274: in save
    _save_hdf(data, self.settings, entry, variation, errored)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

data = <cantera.onedim.FreeFlame object at 0x000002B31F4BD2C0>, settings = {'mode': 'a'}, entry = 'foo', variation = None, errored = False

    def _save_hdf(data, settings, entry, variation, errored=False):
        filename = settings.pop('name')
        mode = settings.pop('mode', 'a')

        if filename is None:
            return

        filepath = settings.pop('path')
        force = settings.pop('force')
        settings.pop('format')

        if filepath is not None:
            filename = Path(filepath) / filename

        # file check
        fexists = Path(filename).is_file()

        if fexists:
            with h5py.File(filename, 'r') as hdf:
                for group in hdf.keys():
                    if group == entry and mode == 'a' and not force:
                        msg = ('Cannot overwrite existing '
                               'group `{}` (use force to override)')
                        raise RuntimeError(msg.format(entry))
                    elif group == entry and mode == 'a' and force:
                        mode = 'w'

        settings.update(mode=mode)

        hdf_kwargs = {'mode', 'append', 'compression', 'compression_opts'}
        kwargs = {k: v for k, v in settings.items() if k in hdf_kwargs}

        if errored:
            with h5py.File(filename, mode) as hdf:
                grp = hdf.create_group(entry)
                grp.attrs[data[0]] = data[1]
        else:
            if type(data).__name__ == 'SolutionArray':
                if variation is not None:
                    attrs = variation
                else:
                    attrs = {}
                data.write_hdf(filename=filename, group=entry,
                               attrs=attrs, **kwargs)
            elif type(data).__name__ in ['FreeFlame']:
                if variation is not None:
                    description = '_'.join(['{}_{}'.format(k, v) for k, v in variation.items()])
                else:
                    description = None
>               data.write_hdf(filename=filename, group=entry,
                               description=description, **kwargs)
E               AttributeError: 'FreeFlame' object has no attribute 'write_hdf'

ctwrap\output.py:402: AttributeError
_____________________________________________________________ TestYAML.test_ignition _____________________________________________________________

self = <test_parser.TestYAML testMethod=test_ignition>

    def test_ignition(self):

        with open(EXAMPLES / 'ignition.yaml') as stream:
            yaml = YAML(typ='safe')
>           yml = yaml.load(stream, Loader=yaml.SafeLoader)
E           AttributeError: 'YAML' object has no attribute 'SafeLoader'

tests\test_parser.py:217: AttributeError
_____________________________________________________________ TestYAML.test_minimal ______________________________________________________________

self = <test_parser.TestYAML testMethod=test_minimal>

    def test_minimal(self):

        with open(EXAMPLES / 'minimal.yaml') as stream:
            yaml = YAML(typ='safe')
>           defaults = yaml.load(stream, Loader=yaml.SafeLoader)
E           AttributeError: 'YAML' object has no attribute 'SafeLoader'

tests\test_parser.py:202: AttributeError
___________________________________________________________ TestIgnition.test_parallel ___________________________________________________________

self = <test_wrapper.TestIgnition testMethod=test_parallel>

    def test_parallel(self):
        self.assertTrue(self.sh.run_parallel(self.sim))

        if self._out:
            hdf = Path(EXAMPLES) / self._out
>           self.assertTrue(hdf.is_file())
E           AssertionError: False is not true

tests\test_wrapper.py:106: AssertionError
-------------------------------------------------------------- Captured stderr call --------------------------------------------------------------
Process Process-41:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 395, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py", line 684, in __getattr__
    raise AttributeError(
AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
Process Process-48:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 395, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py", line 684, in __getattr__
    raise AttributeError(
AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
Process Process-47:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 395, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py", line 684, in __getattr__
    raise AttributeError(
AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
Process Process-43:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 395, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py", line 684, in __getattr__
    raise AttributeError(
AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
Process Process-49:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 395, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py", line 684, in __getattr__
    raise AttributeError(
AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
Process Process-42:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 395, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py", line 684, in __getattr__
    raise AttributeError(
AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
Process Process-44:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 395, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py", line 684, in __getattr__
    raise AttributeError(
AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
Process Process-50:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 395, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\composite.py", line 684, in __getattr__
    raise AttributeError(
AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
_________________________________________________________ TestFreeFlame.test_commandline _________________________________________________________

self = <test_wrapper.TestFreeFlame testMethod=test_commandline>

    def test_commandline(self):
        if self._skip_long:
            return
        cmd = ['ctwrap', 'run']
        if isinstance(self._module, str):
            name = self._module
        else:
            name = self._module.__name__.split('.')[-1]
            if self._path:
                name = str(Path(self._path) / '{}.py'.format(name))
        yaml = str(Path(EXAMPLES) / self._yaml)
        pars = [name, yaml, '--parallel']
        if self._strategy:
            pars += ['--strategy', self._strategy]

        self.maxDiff = None
        process = subprocess.Popen(cmd + pars,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)
        _, stderr = process.communicate()
>       self.assertEqual(stderr.decode(), '')
E       AssertionError: 'C:\\Users\\erwan\\anaconda3\\envs\\bloc\\[11234 chars]\r\n' != ''
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model
E       - Process Process-2:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - Process Process-10:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - Process Process-5:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - Process Process-1:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - Process Process-9:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - Process Process-8:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - Process Process-6:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - Process Process-3:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - Process Process-4:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - Process Process-7:
E       - Traceback (most recent call last):
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
E       -     self.run()
E       -   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
E       -     self._target(*self._args, **self._kwargs)
E       -   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
E       -     out.save(data, entry=task, variation=variations[task], errored=errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
E       -     _save_hdf(data, self.settings, entry, variation, errored)
E       -   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
E       -     data.write_hdf(filename=filename, group=entry,
E       -     ^^^^^^^^^^^^^^
E       - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
E       - c:\github\ctwrap\ctwrap\output.py:349: RuntimeWarning: Output of metadata failed with error message:
E       - [Errno 2] Unable to synchronously open file (unable to open file: name = 'C:\GitHub\ctwrap\ctwrap\yaml\freeflame.h5', errno = 2, error message = 'No such file or directory', flags = 1, o_flags = 2)
E       -   warnings.warn(msg, RuntimeWarning)

tests\test_wrapper.py:128: AssertionError
____________________________________________________________ TestFreeFlame.test_main _____________________________________________________________

self = <test_wrapper.TestFreeFlame testMethod=test_main>

    def test_main(self):

        if isinstance(self._module, str):
            name = self._module
        else:
            name = self._module.__file__

        self.maxDiff = None
        process = subprocess.Popen(['python', name],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)
        _, stderr = process.communicate()
>       self.assertEqual(stderr.decode(), '')
E       AssertionError: "C:\\Users\\erwan\\anaconda3\\envs\\bloc\[195 chars]\r\n" != ''
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model

tests\test_wrapper.py:146: AssertionError
__________________________________________________________ TestFreeFlame.test_parallel ___________________________________________________________

self = <test_wrapper.TestFreeFlame testMethod=test_parallel>

    def test_parallel(self):
        self.assertTrue(self.sh.run_parallel(self.sim))

        if self._out:
            hdf = Path(EXAMPLES) / self._out
>           self.assertTrue(hdf.is_file())
E           AssertionError: False is not true

tests\test_wrapper.py:106: AssertionError
-------------------------------------------------------------- Captured stdout call --------------------------------------------------------------
    flamespeed = 0.924983 m/s (mix)
    flamespeed = 1.728957 m/s (mix)
    flamespeed = 2.314446 m/s (mix)
    flamespeed = 0.201402 m/s (mix)
    flamespeed = 3.039609 m/s (mix)
    flamespeed = 2.706206 m/s (mix)
    flamespeed = 2.939611 m/s (mix)
    flamespeed = 3.034722 m/s (mix)
    flamespeed = 2.964194 m/s (mix)
    flamespeed = 2.851600 m/s (mix)
-------------------------------------------------------------- Captured stderr call --------------------------------------------------------------
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
Process Process-88:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-84:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-81:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-89:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-86:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-83:
Process Process-87:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-82:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-85:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-90:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
___________________________________________________________ TestFreeFlame.test_serial ____________________________________________________________

self = <test_wrapper.TestFreeFlame testMethod=test_serial>

    def test_serial(self):
        if self._skip_long:
            return
>       self.assertTrue(self.sh.run_serial(self.sim))

tests\test_wrapper.py:95:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ctwrap\handler.py:347: in run_serial
    _worker(sim._module, self._strategy.definition, self._output,
ctwrap\handler.py:530: in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
ctwrap\output.py:274: in save
    _save_hdf(data, self.settings, entry, variation, errored)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

data = <cantera.onedim.FreeFlame object at 0x000002B31F7C0C40>, settings = {'mode': 'a'}, entry = 'case_00', variation = {'upstream.phi': 0.4}
errored = False

    def _save_hdf(data, settings, entry, variation, errored=False):
        filename = settings.pop('name')
        mode = settings.pop('mode', 'a')

        if filename is None:
            return

        filepath = settings.pop('path')
        force = settings.pop('force')
        settings.pop('format')

        if filepath is not None:
            filename = Path(filepath) / filename

        # file check
        fexists = Path(filename).is_file()

        if fexists:
            with h5py.File(filename, 'r') as hdf:
                for group in hdf.keys():
                    if group == entry and mode == 'a' and not force:
                        msg = ('Cannot overwrite existing '
                               'group `{}` (use force to override)')
                        raise RuntimeError(msg.format(entry))
                    elif group == entry and mode == 'a' and force:
                        mode = 'w'

        settings.update(mode=mode)

        hdf_kwargs = {'mode', 'append', 'compression', 'compression_opts'}
        kwargs = {k: v for k, v in settings.items() if k in hdf_kwargs}

        if errored:
            with h5py.File(filename, mode) as hdf:
                grp = hdf.create_group(entry)
                grp.attrs[data[0]] = data[1]
        else:
            if type(data).__name__ == 'SolutionArray':
                if variation is not None:
                    attrs = variation
                else:
                    attrs = {}
                data.write_hdf(filename=filename, group=entry,
                               attrs=attrs, **kwargs)
            elif type(data).__name__ in ['FreeFlame']:
                if variation is not None:
                    description = '_'.join(['{}_{}'.format(k, v) for k, v in variation.items()])
                else:
                    description = None
>               data.write_hdf(filename=filename, group=entry,
                               description=description, **kwargs)
E               AttributeError: 'FreeFlame' object has no attribute 'write_hdf'

ctwrap\output.py:402: AttributeError
-------------------------------------------------------------- Captured stdout call --------------------------------------------------------------
    flamespeed = 0.201402 m/s (mix)
_________________________________________________________ TestFreeFlameMatrix.test_main __________________________________________________________

self = <test_wrapper.TestFreeFlameMatrix testMethod=test_main>

    def test_main(self):

        if isinstance(self._module, str):
            name = self._module
        else:
            name = self._module.__file__

        self.maxDiff = None
        process = subprocess.Popen(['python', name],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)
        _, stderr = process.communicate()
>       self.assertEqual(stderr.decode(), '')
E       AssertionError: "C:\\Users\\erwan\\anaconda3\\envs\\bloc\[195 chars]\r\n" != ''
E       - C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
E       -   self.flame.transport_model = model

tests\test_wrapper.py:146: AssertionError
_______________________________________________________ TestFreeFlameMatrix.test_parallel ________________________________________________________

self = <test_wrapper.TestFreeFlameMatrix testMethod=test_parallel>

    def test_parallel(self):
        self.assertTrue(self.sh.run_parallel(self.sim))

        if self._out:
            hdf = Path(EXAMPLES) / self._out
>           self.assertTrue(hdf.is_file())
E           AssertionError: False is not true

tests\test_wrapper.py:106: AssertionError
-------------------------------------------------------------- Captured stdout call --------------------------------------------------------------
    flamespeed = 1.728957 m/s (mix)
    flamespeed = 0.201402 m/s (mix)
    flamespeed = 2.706206 m/s (mix)
    flamespeed = 3.039609 m/s (mix)
    flamespeed = 2.964194 m/s (mix)
    flamespeed = 2.720348 m/s (mix)
-------------------------------------------------------------- Captured stderr call --------------------------------------------------------------
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
  self.flame.transport_model = model
Process Process-91:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-93:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-94:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-100:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-95:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
Process Process-99:
Traceback (most recent call last):
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
    out.save(data, entry=task, variation=variations[task], errored=errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
    _save_hdf(data, self.settings, entry, variation, errored)
  File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
    data.write_hdf(filename=filename, group=entry,
    ^^^^^^^^^^^^^^
AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
================================================================ warnings summary ================================================================
tests/test_wrapper.py::TestIgnition::test_parallel
  c:\github\ctwrap\ctwrap\output.py:349: RuntimeWarning: Output of metadata failed with error message:
  [Errno 2] Unable to synchronously open file (unable to open file: name = 'C:\GitHub\ctwrap\ctwrap\yaml\ignition.h5', errno = 2, error message = 'No such file or directory', flags = 1, o_flags = 2)
    warnings.warn(msg, RuntimeWarning)

tests/test_wrapper.py::TestFreeFlame::test_parallel
tests/test_wrapper.py::TestFreeFlameMatrix::test_parallel
  c:\github\ctwrap\ctwrap\output.py:349: RuntimeWarning: Output of metadata failed with error message:
  [Errno 2] Unable to synchronously open file (unable to open file: name = 'C:\GitHub\ctwrap\ctwrap\yaml\freeflame.h5', errno = 2, error message = 'No such file or directory', flags = 1, o_flags = 2)
    warnings.warn(msg, RuntimeWarning)

tests/test_wrapper.py::TestFreeFlame::test_restart
  C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
    self.flame.transport_model = model

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform win32, python 3.11.11-final-0 ----------
Name                            Stmts   Miss  Cover
---------------------------------------------------
ctwrap\__init__.py                  6      0   100%
ctwrap\_version.py                  5      1    80%
ctwrap\bin\ctwrap.py               68     26    62%
ctwrap\handler.py                 214     40    81%
ctwrap\modules\__init__.py          5      0   100%
ctwrap\modules\equilibrium.py      37      4    89%
ctwrap\modules\freeflame.py        41      5    88%
ctwrap\modules\ignition.py         35      2    94%
ctwrap\modules\minimal.py          12      0   100%
ctwrap\modules\solution.py         25      6    76%
ctwrap\output.py                  214     65    70%
ctwrap\parser.py                  111     17    85%
ctwrap\strategy.py                202     29    86%
ctwrap\wrapper.py                  55      4    93%
---------------------------------------------------
TOTAL                            1030    199    81%


```

</details>



Summary of failures : 

```

============================================================ short test summary info =============================================================
FAILED tests/test_notebooks.py::TestNotebooks::test_commandline_example - AssertionError: 1 is not false
FAILED tests/test_notebooks.py::TestNotebooks::test_equilibrium_example - AssertionError: 1 is not false
FAILED tests/test_notebooks.py::TestNotebooks::test_freeflame_example - AssertionError: 1 is not false
FAILED tests/test_notebooks.py::TestNotebooks::test_ignition_example - AssertionError: 1 is not false
FAILED tests/test_notebooks.py::TestNotebooks::test_minimal_example - AssertionError: 1 is not false
FAILED tests/test_output.py::TestSolutionArray::test_dir - AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
FAILED tests/test_output.py::TestSolutionArray::test_hdf - AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
FAILED tests/test_output.py::TestSolutionArray::test_load_like - AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
FAILED tests/test_output.py::TestSolutionArray::test_output - AttributeError: 'SolutionArray' object has no attribute 'write_hdf'
FAILED tests/test_output.py::TestFreeFlame::test_dir - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
FAILED tests/test_output.py::TestFreeFlame::test_load_like - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
FAILED tests/test_output.py::TestFreeFlame::test_output - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
FAILED tests/test_parser.py::TestYAML::test_ignition - AttributeError: 'YAML' object has no attribute 'SafeLoader'
FAILED tests/test_parser.py::TestYAML::test_minimal - AttributeError: 'YAML' object has no attribute 'SafeLoader'
FAILED tests/test_wrapper.py::TestIgnition::test_parallel - AssertionError: False is not true
FAILED tests/test_wrapper.py::TestFreeFlame::test_commandline - AssertionError: 'C:\\Users\\erwan\\anaconda3\\envs\\bloc\\[11234 chars]\r\n' != ''
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
- Process Process-2:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- Process Process-10:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- Process Process-5:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- Process Process-1:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- Process Process-9:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- Process Process-8:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- Process Process-6:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- Process Process-3:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- Process Process-4:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- Process Process-7:
- Traceback (most recent call last):
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 314, in _bootstrap
-     self.run()
-   File "C:\Users\erwan\anaconda3\envs\bloc\Lib\multiprocessing\process.py", line 108, in run
-     self._target(*self._args, **self._kwargs)
-   File "c:\github\ctwrap\ctwrap\handler.py", line 528, in _worker
-     out.save(data, entry=task, variation=variations[task], errored=errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 274, in save
-     _save_hdf(data, self.settings, entry, variation, errored)
-   File "c:\github\ctwrap\ctwrap\output.py", line 402, in _save_hdf
-     data.write_hdf(filename=filename, group=entry,
-     ^^^^^^^^^^^^^^
- AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
- c:\github\ctwrap\ctwrap\output.py:349: RuntimeWarning: Output of metadata failed with error message:
- [Errno 2] Unable to synchronously open file (unable to open file: name = 'C:\GitHub\ctwrap\ctwrap\yaml\freeflame.h5', errno = 2, error message = 'No such file or directory', flags = 1, o_flags = 2)
-   warnings.warn(msg, RuntimeWarning)
FAILED tests/test_wrapper.py::TestFreeFlame::test_main - AssertionError: "C:\\Users\\erwan\\anaconda3\\envs\\bloc\[195 chars]\r\n" != ''
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
FAILED tests/test_wrapper.py::TestFreeFlame::test_parallel - AssertionError: False is not true
FAILED tests/test_wrapper.py::TestFreeFlame::test_serial - AttributeError: 'FreeFlame' object has no attribute 'write_hdf'
FAILED tests/test_wrapper.py::TestFreeFlameMatrix::test_main - AssertionError: "C:\\Users\\erwan\\anaconda3\\envs\\bloc\[195 chars]\r\n" != ''
- C:\Users\erwan\anaconda3\envs\bloc\Lib\site-packages\cantera\onedim.py:194: DeprecationWarning: FactoryBase::canonicalize: Model name 'Mix' is deprecated. Use 'mixture-averaged' instead.
-   self.flame.transport_model = model
FAILED tests/test_wrapper.py::TestFreeFlameMatrix::test_parallel - AssertionError: False is not true
============================================= 21 failed, 126 passed, 4 warnings in 362.96s (0:06:02) =============================================

```

## Final To-Do


- [ ] write_hdf does not seem to be a public method of FreeFlame according [to Cantera main code](https://github.com/Cantera/cantera/blob/2e0d8acddc325a0193565a05427a0c827a5107bc/interfaces/cython/cantera/onedim.py#L582); to_hdf() was created for SolutionArray but not for FreeFlame ==> won't fix it in ctwarp for the moment
- [ ] Model name 'Mix' is deprecated. Use 'mixture-averaged' instead. : I haven't looked into this
- [ ] Investigate `AssertionError: 1 is not false` of failing TestNotebooks
- [ ] Investigate failing TestIgnition::test_parallel